### PR TITLE
feat: add `uAmplitude` props

### DIFF
--- a/packages/shadergradient-v2/src/Plane/Mesh.tsx
+++ b/packages/shadergradient-v2/src/Plane/Mesh.tsx
@@ -3,10 +3,15 @@ import { vertexShader, fragmentShader } from './shader'
 import { useFrame } from '@react-three/fiber'
 import { degToRad } from '@/utils'
 import * as THREE from 'three'
+import { MeshT } from '@/types'
 
-const amplitude = 2
-
-export function Mesh({ width, height, position, rotation }) {
+export function Mesh({
+  width,
+  height,
+  position,
+  rotation,
+  uAmplitude,
+}: MeshT) {
   const materialRef = useRef()
   const { positionX, positionY, positionZ } = position
   const { rotationX, rotationY, rotationZ } = rotation
@@ -15,7 +20,7 @@ export function Mesh({ width, height, position, rotation }) {
     const elapsedTime = clock.getElapsedTime()
     if (materialRef.current) {
       materialRef.current.uniforms.u_time.value = elapsedTime
-      materialRef.current.uniforms.u_amplitude.value = amplitude
+      materialRef.current.uniforms.u_amplitude.value = uAmplitude
     }
   })
 
@@ -34,7 +39,7 @@ export function Mesh({ width, height, position, rotation }) {
         // wireframe={true}
         uniforms={{
           u_time: { value: 0.0 },
-          u_amplitude: { value: amplitude },
+          u_amplitude: { value: uAmplitude },
           u_width: { value: width },
           u_height: { value: height },
         }}

--- a/packages/shadergradient-v2/src/Plane/Mesh.tsx
+++ b/packages/shadergradient-v2/src/Plane/Mesh.tsx
@@ -5,13 +5,7 @@ import { degToRad } from '@/utils'
 import * as THREE from 'three'
 import { MeshT } from '@/types'
 
-export function Mesh({
-  width,
-  height,
-  position,
-  rotation,
-  uAmplitude,
-}: MeshT) {
+export function Mesh({ width, height, position, rotation, uAmplitude }: MeshT) {
   const materialRef = useRef()
   const { positionX, positionY, positionZ } = position
   const { rotationX, rotationY, rotationZ } = rotation
@@ -20,7 +14,6 @@ export function Mesh({
     const elapsedTime = clock.getElapsedTime()
     if (materialRef.current) {
       materialRef.current.uniforms.u_time.value = elapsedTime
-      materialRef.current.uniforms.u_amplitude.value = uAmplitude
     }
   })
 

--- a/packages/shadergradient-v2/src/ShaderGradient.tsx
+++ b/packages/shadergradient-v2/src/ShaderGradient.tsx
@@ -4,34 +4,16 @@ import { OrbitControls } from '@react-three/drei'
 import { Mesh as PlaneMesh } from './Plane'
 import { Mesh as WaterPlaneMesh } from './WaterPlane'
 import { Mesh as SphereMesh } from './Sphere'
+import { ShaderGradientProps } from './types'
 
 const width = 10
 const height = 10
 
-type ShaderGradientType = 'plane' | 'waterPlane' | 'sphere'
-
-interface Position {
-  positionX: number
-  positionY: number
-  positionZ: number
-}
-
-interface Rotation {
-  rotationX: number
-  rotationY: number
-  rotationZ: number
-}
-
-interface ShaderGradientProps {
-  position: Position
-  rotation: Rotation
-  type: ShaderGradientType
-}
-
 export function ShaderGradient({
+  type,
   position,
   rotation,
-  type,
+  uAmplitude,
 }: ShaderGradientProps): JSX.Element {
   return (
     <Canvas resize={{ offsetSize: true }}>
@@ -41,6 +23,7 @@ export function ShaderGradient({
           height={height}
           position={position}
           rotation={rotation}
+          uAmplitude={uAmplitude}
         />
       )}
       {type === 'waterPlane' && (
@@ -49,6 +32,7 @@ export function ShaderGradient({
           height={height}
           position={position}
           rotation={rotation}
+          uAmplitude={uAmplitude}
         />
       )}
       {type === 'sphere' && (
@@ -57,6 +41,7 @@ export function ShaderGradient({
           height={height}
           position={position}
           rotation={rotation}
+          uAmplitude={uAmplitude}
         />
       )}
       <OrbitControls />

--- a/packages/shadergradient-v2/src/Sphere/Mesh.tsx
+++ b/packages/shadergradient-v2/src/Sphere/Mesh.tsx
@@ -7,13 +7,7 @@ import { MeshT } from '@/types'
 
 const meshCount = 192
 
-export function Mesh({
-  width,
-  height,
-  position,
-  rotation,
-  uAmplitude,
-}: MeshT) {
+export function Mesh({ width, height, position, rotation, uAmplitude }: MeshT) {
   const materialRef = useRef()
   const { positionX, positionY, positionZ } = position
   const { rotationX, rotationY, rotationZ } = rotation
@@ -22,7 +16,6 @@ export function Mesh({
     const elapsedTime = clock.getElapsedTime()
     if (materialRef.current) {
       materialRef.current.uniforms.u_time.value = elapsedTime
-      materialRef.current.uniforms.u_amplitude.value = uAmplitude
     }
   })
 

--- a/packages/shadergradient-v2/src/Sphere/Mesh.tsx
+++ b/packages/shadergradient-v2/src/Sphere/Mesh.tsx
@@ -3,11 +3,17 @@ import { vertexShader, fragmentShader } from './shader'
 import { useFrame } from '@react-three/fiber'
 import { degToRad } from '@/utils'
 import * as THREE from 'three'
+import { MeshT } from '@/types'
 
-const amplitude = 2
 const meshCount = 192
 
-export function Mesh({ width, height, position, rotation }) {
+export function Mesh({
+  width,
+  height,
+  position,
+  rotation,
+  uAmplitude,
+}: MeshT) {
   const materialRef = useRef()
   const { positionX, positionY, positionZ } = position
   const { rotationX, rotationY, rotationZ } = rotation
@@ -16,7 +22,7 @@ export function Mesh({ width, height, position, rotation }) {
     const elapsedTime = clock.getElapsedTime()
     if (materialRef.current) {
       materialRef.current.uniforms.u_time.value = elapsedTime
-      materialRef.current.uniforms.u_amplitude.value = amplitude
+      materialRef.current.uniforms.u_amplitude.value = uAmplitude
     }
   })
 
@@ -35,7 +41,7 @@ export function Mesh({ width, height, position, rotation }) {
         // wireframe={true}
         uniforms={{
           u_time: { value: 0.0 },
-          u_amplitude: { value: amplitude },
+          u_amplitude: { value: uAmplitude },
           u_width: { value: width },
           u_height: { value: height },
         }}

--- a/packages/shadergradient-v2/src/WaterPlane/Mesh.tsx
+++ b/packages/shadergradient-v2/src/WaterPlane/Mesh.tsx
@@ -7,13 +7,7 @@ import { MeshT } from '@/types'
 
 const meshCount = 192
 
-export function Mesh({
-  width,
-  height,
-  position,
-  rotation,
-  uAmplitude,
-}: MeshT) {
+export function Mesh({ width, height, position, rotation, uAmplitude }: MeshT) {
   const materialRef = useRef()
   const { positionX, positionY, positionZ } = position
   const { rotationX, rotationY, rotationZ } = rotation
@@ -22,7 +16,6 @@ export function Mesh({
     const elapsedTime = clock.getElapsedTime()
     if (materialRef.current) {
       materialRef.current.uniforms.u_time.value = elapsedTime
-      materialRef.current.uniforms.u_amplitude.value = uAmplitude
     }
   })
 

--- a/packages/shadergradient-v2/src/WaterPlane/Mesh.tsx
+++ b/packages/shadergradient-v2/src/WaterPlane/Mesh.tsx
@@ -3,11 +3,17 @@ import { vertexShader, fragmentShader } from './shader'
 import { useFrame } from '@react-three/fiber'
 import { degToRad } from '@/utils'
 import * as THREE from 'three'
+import { MeshT } from '@/types'
 
-const amplitude = 2
 const meshCount = 192
 
-export function Mesh({ width, height, position, rotation }) {
+export function Mesh({
+  width,
+  height,
+  position,
+  rotation,
+  uAmplitude,
+}: MeshT) {
   const materialRef = useRef()
   const { positionX, positionY, positionZ } = position
   const { rotationX, rotationY, rotationZ } = rotation
@@ -16,7 +22,7 @@ export function Mesh({ width, height, position, rotation }) {
     const elapsedTime = clock.getElapsedTime()
     if (materialRef.current) {
       materialRef.current.uniforms.u_time.value = elapsedTime
-      materialRef.current.uniforms.u_amplitude.value = amplitude
+      materialRef.current.uniforms.u_amplitude.value = uAmplitude
     }
   })
 
@@ -35,7 +41,7 @@ export function Mesh({ width, height, position, rotation }) {
         // wireframe={true}
         uniforms={{
           u_time: { value: 0.0 },
-          u_amplitude: { value: amplitude },
+          u_amplitude: { value: uAmplitude },
           u_width: { value: width },
           u_height: { value: height },
         }}

--- a/packages/shadergradient-v2/src/WithControls.ts
+++ b/packages/shadergradient-v2/src/WithControls.ts
@@ -1,5 +1,8 @@
-import { ShaderGradient } from './ShaderGradient'
+import { ShaderGradient as OriginalShaderGradient } from './ShaderGradient'
 import { ControlType } from 'framer'
+import { ShaderGradientWithControls } from './types'
+
+const ShaderGradient = OriginalShaderGradient as ShaderGradientWithControls
 
 ShaderGradient.propertyControls = {
   type: {
@@ -57,6 +60,15 @@ ShaderGradient.propertyControls = {
         defaultValue: 0,
       },
     },
+  },
+  uAmplitude: {
+    title: 'uAmplitude',
+    type: ControlType.Number,
+    min: 0,
+    max: 7,
+    step: 0.1,
+    displayStepper: true,
+    defaultValue: 2,
   },
 }
 

--- a/packages/shadergradient-v2/src/types.ts
+++ b/packages/shadergradient-v2/src/types.ts
@@ -1,0 +1,35 @@
+import { PropertyControls } from 'framer'
+
+export type ShaderGradientType = 'plane' | 'waterPlane' | 'sphere'
+
+export interface Position {
+  positionX: number
+  positionY: number
+  positionZ: number
+}
+
+export interface Rotation {
+  rotationX: number
+  rotationY: number
+  rotationZ: number
+}
+
+export interface ShaderGradientProps {
+  position: Position
+  rotation: Rotation
+  type: ShaderGradientType
+  uAmplitude?: number
+}
+
+export interface ShaderGradientWithControls
+  extends React.FC<ShaderGradientProps> {
+  propertyControls?: PropertyControls<ShaderGradientProps>
+}
+
+export interface MeshT {
+  width: number
+  height: number
+  position: Position
+  rotation: Rotation
+  uAmplitude?: number
+}


### PR DESCRIPTION
## Description
- add `uAmplitude` props

## Review Point
1. Created a separate `types.ts` file to manage all type definitions in one place. This improves code organization and reusability of types across the project.
2. Refactored the management of the uAmplitude value:
    - Previously, each of Plane, Sphere, and WaterPlane components had their own `const amplitude = 2` definition.
    - Now, this is managed in the ShaderGradient component as a prop with a default value.
    - Also considered Framer users by setting `defaultValue: 2` in propertyControls, ensuring consistency in the initial view when adding the component.
3. Implemented type casting for ShaderGradient to include propertyControls, resolving TypeScript errors related to Framer integration.
4. Updated propertyControls for uAmplitude to match the UI slider settings (min: 0, max: 7, step: 0.1), ensuring consistency between the code and the user interface.