### PR TITLE
chore: specify node, pnpm versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     "prettier-plugin-tailwindcss": "^0.1.11",
     "turbo": "^1.10.12"
   },
-  "packageManager": "pnpm@7.15.0",
+  "packageManager": "pnpm@8.14.0",
+  "engines": {
+    "node": ">=14.0.0",
+    "pnpm": "^8.14.0"
+  },
   "version": "0.0.1"
 }


### PR DESCRIPTION
closed #102 

## Description
To ensure consistency across development environments, specify the recommended versions of Node.js and pnpm in the package.json file.

```json
  "packageManager": "pnpm@8.14.0",
  "engines": {
    "node": ">=14.0.0",
    "pnpm": "^8.14.0"
  },
```