### PR TITLE
refactor: modify MeshType

### DIFF
--- a/packages/shadergradient-v2/src/ShaderGradient/Controls/Controls.tsx
+++ b/packages/shadergradient-v2/src/ShaderGradient/Controls/Controls.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { OrbitControls } from '@react-three/drei'
 
 export function Controls(): JSX.Element {

--- a/packages/shadergradient-v2/src/ShaderGradient/Lights/Lights.tsx
+++ b/packages/shadergradient-v2/src/ShaderGradient/Lights/Lights.tsx
@@ -1,3 +1,5 @@
+import React from 'react'
+
 export function Lights(): JSX.Element {
   return (
     <>

--- a/packages/shadergradient-v2/src/ShaderGradient/Mesh/Geometry.tsx
+++ b/packages/shadergradient-v2/src/ShaderGradient/Mesh/Geometry.tsx
@@ -1,3 +1,5 @@
+import React from 'react'
+
 const meshCount = 192
 
 export function Geometry({ type }): JSX.Element {

--- a/packages/shadergradient-v2/src/ShaderGradient/Mesh/Mesh.tsx
+++ b/packages/shadergradient-v2/src/ShaderGradient/Mesh/Mesh.tsx
@@ -5,13 +5,8 @@ import { vertexShader, fragmentShader } from '@/shaders/a'
 // import { vertexShader, fragmentShader } from '@/shaders/base'
 
 export function Mesh({
-  positionX,
-  positionY,
-  positionZ,
-  rotationX,
-  rotationY,
-  rotationZ,
-
+  position,
+  rotation,
   type,
   color1,
   color2,
@@ -25,8 +20,8 @@ export function Mesh({
 }: MeshT): JSX.Element {
   return (
     <mesh
-      position={[positionX, positionY, positionZ]}
-      rotation={[rotationX, rotationY, rotationZ]}
+      position={[position.positionX, position.positionY, position.positionZ]}
+      rotation={[rotation.rotationX, rotation.rotationY, rotation.rotationZ]}
     >
       <Geometry type={type} />
       <Materials

--- a/packages/shadergradient-v2/src/ShaderGradient/PostProcessing/PostProcessing.tsx
+++ b/packages/shadergradient-v2/src/ShaderGradient/PostProcessing/PostProcessing.tsx
@@ -1,3 +1,5 @@
+import React from 'react'
+
 export function PostProcessing(): JSX.Element {
   return <></>
 }

--- a/packages/shadergradient-v2/src/presets.ts
+++ b/packages/shadergradient-v2/src/presets.ts
@@ -5,12 +5,16 @@ export const presets = {
     title: 'Base',
     color: 'white',
     props: {
-      positionX: 0,
-      positionY: 0,
-      positionZ: 0,
-      rotationX: 0,
-      rotationY: 0,
-      rotationZ: 0,
+      position: {
+        positionX: -1.4,
+        positionY: 0,
+        positionZ: 0,
+      },
+      rotation: {
+        rotationX: 0,
+        rotationY: 10,
+        rotationZ: 50,
+      },
       uAmplitude: 2,
 
       color1: '#ff5005',
@@ -23,7 +27,16 @@ export const presets = {
     color: 'white',
     props: {
       type: 'plane' as typeT,
-
+      position: {
+        positionX: -1.4,
+        positionY: 0,
+        positionZ: 0,
+      },
+      rotation: {
+        rotationX: 0,
+        rotationY: 10,
+        rotationZ: 50,
+      },
       uAmplitude: 1,
       uDensity: 1.3,
       uSpeed: 0.4,
@@ -52,17 +65,8 @@ export const presets = {
       lightType: '3d',
       pixelDensity: 1,
       fov: 45,
-      positionX: -1.4,
-      positionY: 0,
-      positionZ: 0,
-      reflection: 0.1,
-      rotationX: 0,
-      rotationY: 10,
-      rotationZ: 50,
       shader: 'defaults',
-
       animate: 'on' as animateT,
-
       wireframe: false,
     },
   },

--- a/packages/shadergradient-v2/src/types.ts
+++ b/packages/shadergradient-v2/src/types.ts
@@ -26,12 +26,8 @@ export type MeshT = {
   uDensity?: number
   uFrequency?: number
   uAmplitude?: number
-  positionX?: number
-  positionY?: number
-  positionZ?: number
-  rotationX?: number
-  rotationY?: number
-  rotationZ?: number
+  position?: Position
+  rotation?: Rotation
   color1?: string
   color2?: string
   color3?: string

--- a/packages/shadergradient-v2/src/utils/urlUtils.ts
+++ b/packages/shadergradient-v2/src/utils/urlUtils.ts
@@ -1,0 +1,36 @@
+import { GradientT } from "@/types"
+
+export function propsToQuery(props: GradientT): string {
+  const flatProps: Record<string, string> = {}
+
+  Object.entries(props).forEach(([key, value]) => {
+    if (typeof value === 'object' && value !== null) {
+      Object.entries(value).forEach(([nestedKey, nestedValue]) => {
+        flatProps[`${key}.${nestedKey}`] = String(nestedValue)
+      })
+    } else {
+      flatProps[key] = String(value)
+    }
+  })
+
+  return new URLSearchParams(flatProps).toString()
+}
+
+export function queryToProps(query: string): GradientT {
+  const params = new URLSearchParams(query)
+  const props: Partial<GradientT> = {}
+
+  params.forEach((value, key) => {
+    const [parent, child] = key.split('.')
+    if (child) {
+      if (!props[parent]) {
+        props[parent] = {}
+      }
+      props[parent][child] = isNaN(Number(value)) ? value : Number(value)
+    } else {
+      props[key] = isNaN(Number(value)) ? value : Number(value)
+    }
+  })
+
+  return props as GradientT
+}


### PR DESCRIPTION
In ShaderGradient.propertyControls, `position` and `rotation` were defined as objects, but in the GradientT type, these were defined as individual properties (`positionX`, `positionY`, `positionZ`, `rotationX`, `rotationY`, `rotationZ`). This caused a type mismatch error.

