### PR TITLE
fix : add addPropertyControls to clarify the types of Framer properties

### DIFF
--- a/packages/shadergradient-v2/package.json
+++ b/packages/shadergradient-v2/package.json
@@ -24,6 +24,8 @@
     "@react-spring/three": "^9.7.3",
     "@react-three/drei": "^9.114.3",
     "@react-three/fiber": "^8.17.10",
+    "@types/react": "18.3.11",
+    "@types/react-dom": "18.3.1",
     "@types/socket.io": "^3.0.2",
     "camera-controls": "2.9.0",
     "concurrently": "^9.0.0",

--- a/packages/shadergradient-v2/src/WithFramerControls.tsx
+++ b/packages/shadergradient-v2/src/WithFramerControls.tsx
@@ -1,10 +1,41 @@
-import { ShaderGradient as OriginalShaderGradient } from './ShaderGradient'
-import { ControlType } from 'framer'
-import { ShaderGradientWithControls } from './types'
+import { ShaderGradient } from './ShaderGradient'
+import { addPropertyControls, ControlType } from 'framer'
+import { GradientT } from './types'
 
-const ShaderGradient = OriginalShaderGradient as ShaderGradientWithControls
+type FramerShaderGradientProps = GradientT & {
+  position?: {
+    positionX: number
+    positionY: number
+    positionZ: number
+  }
+  rotation?: {
+    rotationX: number
+    rotationY: number
+    rotationZ: number
+  }
+}
 
-ShaderGradient.propertyControls = {
+function FramerShaderGradient({
+  position,
+  rotation,
+  ...rest
+}: FramerShaderGradientProps) {
+  const { positionX, positionY, positionZ } = position
+  const { rotationX, rotationY, rotationZ } = rotation
+  return (
+    <ShaderGradient
+      positionX={positionX}
+      positionY={positionY}
+      positionZ={positionZ}
+      rotationX={rotationX}
+      rotationY={rotationY}
+      rotationZ={rotationZ}
+      {...rest}
+    />
+  )
+}
+
+addPropertyControls(FramerShaderGradient, {
   type: {
     type: ControlType.Enum,
     options: ['plane', 'sphere', 'waterPlane'],
@@ -24,11 +55,13 @@ ShaderGradient.propertyControls = {
         type: ControlType.Number,
         step: 0.1,
         displayStepper: true,
+        defaultValue: 0,
       },
       positionZ: {
         type: ControlType.Number,
         step: 0.1,
         displayStepper: true,
+        defaultValue: 0,
       },
     },
   },
@@ -70,18 +103,9 @@ ShaderGradient.propertyControls = {
     displayStepper: true,
     defaultValue: 2,
   },
-  color1: {
-    type: ControlType.Color,
-    defaultValue: '#ff5005',
-  },
-  color2: {
-    type: ControlType.Color,
-    defaultValue: '#dbba95',
-  },
-  color3: {
-    type: ControlType.Color,
-    defaultValue: '#d0bce1',
-  },
-}
+  color1: { type: ControlType.Color, defaultValue: '#ff5005' },
+  color2: { type: ControlType.Color, defaultValue: '#dbba95' },
+  color3: { type: ControlType.Color, defaultValue: '#d0bce1' },
+})
 
-export { ShaderGradient }
+export { FramerShaderGradient as ShaderGradient }

--- a/packages/shadergradient-v2/tsconfig.json
+++ b/packages/shadergradient-v2/tsconfig.json
@@ -17,11 +17,7 @@
     "skipLibCheck": true,
     "strict": false,
 
-
-   "lib": [
-      "ES2017",
-      "dom"
-    ],
+    "lib": ["ES2017", "dom"],
     "module": "ESNext",
     "target": "ES6",
     "jsx": "react-jsx",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -588,10 +588,16 @@ importers:
         version: 9.7.3(@react-three/fiber@8.17.10)(react@18.3.1)(three@0.169.0)
       '@react-three/drei':
         specifier: ^9.114.3
-        version: 9.114.3(@react-three/fiber@8.17.10)(@types/three@0.150.0)(react-dom@18.3.1)(react@18.3.1)(three@0.169.0)
+        version: 9.114.3(@react-three/fiber@8.17.10)(@types/react@18.3.11)(@types/three@0.150.0)(react-dom@18.3.1)(react@18.3.1)(three@0.169.0)
       '@react-three/fiber':
         specifier: ^8.17.10
         version: 8.17.10(react-dom@18.3.1)(react@18.3.1)(three@0.169.0)
+      '@types/react':
+        specifier: 18.3.11
+        version: 18.3.11
+      '@types/react-dom':
+        specifier: 18.3.1
+        version: 18.3.1
       '@types/socket.io':
         specifier: ^3.0.2
         version: 3.0.2
@@ -4159,7 +4165,7 @@ packages:
       - immer
     dev: false
 
-  /@react-three/drei@9.114.3(@react-three/fiber@8.17.10)(@types/three@0.150.0)(react-dom@18.3.1)(react@18.3.1)(three@0.169.0):
+  /@react-three/drei@9.114.3(@react-three/fiber@8.17.10)(@types/react@18.3.11)(@types/three@0.150.0)(react-dom@18.3.1)(react@18.3.1)(three@0.169.0):
     resolution: {integrity: sha512-hPKPYmxTb2P1mOdhkouJbKJVcfFK5JmThr/97i4zkweoNzWBHNde090A6r0SFFb4tGaTtHM4/kyfVx5PrzjTMw==}
     peerDependencies:
       '@react-three/fiber': '>=8.0'
@@ -4193,7 +4199,7 @@ packages:
       three-mesh-bvh: 0.7.8(three@0.169.0)
       three-stdlib: 2.30.1(three@0.169.0)
       troika-three-text: 0.49.1(three@0.169.0)
-      tunnel-rat: 0.1.2(react@18.3.1)
+      tunnel-rat: 0.1.2(@types/react@18.3.11)(react@18.3.1)
       utility-types: 3.10.0
       uuid: 9.0.1
       zustand: 3.7.2(react@18.3.1)
@@ -5270,17 +5276,23 @@ packages:
   /@types/react-dom@18.2.23:
     resolution: {integrity: sha512-ZQ71wgGOTmDYpnav2knkjr3qXdAFu0vsk8Ci5w3pGAIdj7/kKAyn+VsQDhXsmzzzepAiI9leWMmubXz690AI/A==}
     dependencies:
-      '@types/react': 18.2.73
+      '@types/react': 18.3.11
+
+  /@types/react-dom@18.3.1:
+    resolution: {integrity: sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==}
+    dependencies:
+      '@types/react': 18.3.11
+    dev: true
 
   /@types/react-reconciler@0.26.7:
     resolution: {integrity: sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ==}
     dependencies:
-      '@types/react': 18.2.73
+      '@types/react': 18.3.11
 
   /@types/react-reconciler@0.28.0:
     resolution: {integrity: sha512-5cjk9ottZAj7eaTsqzPUIlrVbh3hBAO2YaEL1rkjHKB3xNAId7oU8GhzvAX+gfmlfoxTwJnBjPxEHyxkEA1Ffg==}
     dependencies:
-      '@types/react': 18.2.73
+      '@types/react': 18.3.11
 
   /@types/react@17.0.52:
     resolution: {integrity: sha512-vwk8QqVODi0VaZZpDXQCmEmiOuyjEFPY7Ttaw5vjM112LOq37yz1CDJGrRJwA1fYEq4Iitd5rnjd1yWAc/bT+A==}
@@ -5292,6 +5304,12 @@ packages:
 
   /@types/react@18.2.73:
     resolution: {integrity: sha512-XcGdod0Jjv84HOC7N5ziY3x+qL0AfmubvKOZ9hJjJ2yd5EE+KYjWhdOjt387e9HPheHkdggF9atTifMRtyAaRA==}
+    dependencies:
+      '@types/prop-types': 15.7.5
+      csstype: 3.1.1
+
+  /@types/react@18.3.11:
+    resolution: {integrity: sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==}
     dependencies:
       '@types/prop-types': 15.7.5
       csstype: 3.1.1
@@ -8920,13 +8938,13 @@ packages:
       eslint: '*'
       eslint-plugin-import: '*'
     dependencies:
-      debug: 4.3.7
+      debug: 4.3.4
       enhanced-resolve: 5.12.0
       eslint: 8.56.0
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.44.0)(eslint-import-resolver-typescript@3.5.3)(eslint@8.56.0)
       get-tsconfig: 4.5.0
       globby: 13.1.3
-      is-core-module: 2.13.1
+      is-core-module: 2.11.0
       is-glob: 4.0.3
       synckit: 0.8.5
     transitivePeerDependencies:
@@ -8940,13 +8958,13 @@ packages:
       eslint: '*'
       eslint-plugin-import: '*'
     dependencies:
-      debug: 4.3.7
+      debug: 4.3.4
       enhanced-resolve: 5.12.0
       eslint: 8.57.0
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.44.0)(eslint-import-resolver-typescript@3.5.3)(eslint@8.57.0)
       get-tsconfig: 4.5.0
       globby: 13.1.3
-      is-core-module: 2.13.1
+      is-core-module: 2.11.0
       is-glob: 4.0.3
       synckit: 0.8.5
     transitivePeerDependencies:
@@ -17517,10 +17535,10 @@ packages:
       - react
     dev: false
 
-  /tunnel-rat@0.1.2(react@18.3.1):
+  /tunnel-rat@0.1.2(@types/react@18.3.11)(react@18.3.1):
     resolution: {integrity: sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==}
     dependencies:
-      zustand: 4.4.7(@types/react@18.2.73)(react@18.3.1)
+      zustand: 4.4.7(@types/react@18.3.11)(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -18973,3 +18991,24 @@ packages:
       '@types/react': 18.2.73
       react: 18.3.1
       use-sync-external-store: 1.2.0(react@18.3.1)
+    dev: false
+
+  /zustand@4.4.7(@types/react@18.3.11)(react@18.3.1):
+    resolution: {integrity: sha512-QFJWJMdlETcI69paJwhSMJz7PPWjVP8Sjhclxmxmxv/RYI7ZOvR5BHX+ktH0we9gTWQMxcne8q1OY8xxz604gw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+    dependencies:
+      '@types/react': 18.3.11
+      react: 18.3.1
+      use-sync-external-store: 1.2.0(react@18.3.1)
+    dev: true


### PR DESCRIPTION
### Description
related https://github.com/ruucm/shadergradient/pull/105

- add [`addPropertyControls`](https://www.framer.com/developers/components/property-controls?srsltid=AfmBOor2jLlQfHIRl96hQ5BLEjlZDIzw0Nhm5QNBhQCJ8Q9OwYiCeNc3) to clarify the types of Framer properties
- install `@types/react`, `@types/react-dom`

### Review Point
> Additionally, I encountered an issue where 'React' was referencing the UMD global, so I imported React to resolve the issue.

In the package.json of shadergradient, `@types/react` and `@types/react-dom` are included in devDependencies, but they are missing in shadergradient-v2. So, I added them to resolve the aforementioned error.