### PR TITLE
add id on the new v2 component canvas

### DIFF
--- a/packages/shadergradient-v2/src/ShaderGradientCanvas.tsx
+++ b/packages/shadergradient-v2/src/ShaderGradientCanvas.tsx
@@ -57,6 +57,7 @@ export function ShaderGradientCanvas({
             resize={{ offsetSize: true }}
             className={className}
             {...canvasProps(pixelDensity, fov)}
+            id="gradientCanvas" // need id to get an image to export
           >
             {children}
           </Canvas>


### PR DESCRIPTION
피그마 플러그인의 export GIF/image 기능이 다음과 같이 id를 통해서 받아오는 방식이라 새 ShaderGradientCanvas에도 id를 달아줘야할 것 같아요


```
export async function exportImage() {
  return new Promise(async (resolve, reject) => {
    const r3fCanvas = document.getElementById('gradientCanvas')
      .children[0] as HTMLCanvasElement

    const dataURL = r3fCanvas.toDataURL('image/png', 1.0) // full quality

    const image = await loadImage(dataURL)
    console.log('Image has loaded')
    const view: any = await imageToUint8Array(image)
    console.log(`${view.length} bytes!.`)
    resolve(view)
  })
}
```