### PR TITLE
add easy view update

### DIFF
--- a/packages/shadergradient-v2/src/ShaderGradient/Controls/CameraControl.tsx
+++ b/packages/shadergradient-v2/src/ShaderGradient/Controls/CameraControl.tsx
@@ -21,8 +21,8 @@ export function CameraControl({
     const control: any = ref.current
     if (!control) return
 
-    const { type, onUpdate } = props || {}
-    if (!onUpdate) return
+    const { type, onCameraUpdate } = props || {}
+    if (!onCameraUpdate) return
 
     const toDegrees = (radians: number) => Math.round((radians * 180) / Math.PI)
 
@@ -53,7 +53,7 @@ export function CameraControl({
     }
 
     const handleSleep = () => {
-      onUpdate({ ...getAngles(), ...getZoomDistance() })
+      onCameraUpdate({ ...getAngles(), ...getZoomDistance() })
     }
 
     control.addEventListener('sleep', handleSleep)

--- a/packages/shadergradient-v2/src/ShaderGradient/Controls/CameraControl.tsx
+++ b/packages/shadergradient-v2/src/ShaderGradient/Controls/CameraControl.tsx
@@ -80,11 +80,16 @@ export function CameraControl({
           props.type === 'sphere'
             ? (CameraControls as any).ACTION.ZOOM
             : (CameraControls as any).ACTION.DOLLY,
-        // right: (CameraControls as any).ACTION.TRUCK, // disabling pan for now, as we don't support camera position value in props
+        right: (CameraControls as any).ACTION.NONE, // disabling pan for now, as we don't support camera position value in props
         wheel:
           props.type === 'sphere'
             ? (CameraControls as any).ACTION.ZOOM
             : (CameraControls as any).ACTION.DOLLY,
+      }}
+      touches={{
+        one: (CameraControls as any).ACTION.ROTATE,
+        two: (CameraControls as any).ACTION.NONE, // disable touch pan (TRUCK)
+        three: (CameraControls as any).ACTION.NONE,
       }}
     />
   )

--- a/packages/shadergradient-v2/src/ShaderGradient/Controls/CameraControl.tsx
+++ b/packages/shadergradient-v2/src/ShaderGradient/Controls/CameraControl.tsx
@@ -2,6 +2,7 @@ import CameraControls from 'camera-controls'
 import * as THREE from 'three'
 import { useCameraAnimation } from './useCameraAnimation'
 import { extend, useThree, useFrame } from '@react-three/fiber'
+import { useEffect } from 'react'
 
 export function CameraControl({
   smoothTime = 0.05, // default smoothTime of "camera-conrols"
@@ -15,6 +16,53 @@ export function CameraControl({
 
   const ref = useCameraAnimation(props)
 
+  // Emit compact updates when interaction ends or controls go to sleep
+  useEffect(() => {
+    const control: any = ref.current
+    if (!control) return
+
+    const { type, onUpdate } = props || {}
+    if (!onUpdate) return
+
+    const toDegrees = (radians: number) => Math.round((radians * 180) / Math.PI)
+
+    const getAngles = () => ({
+      cAzimuthAngle: toDegrees(control.azimuthAngle),
+      cPolarAngle: toDegrees(control.polarAngle),
+    })
+
+    const getZoomDistance = () => {
+      const result: any = {}
+      if (type === 'sphere') {
+        // Prefer control.zoom (if provided by camera-controls), fallback to camera.zoom
+        const ctrlZoom = control?.zoom
+        if (Number.isFinite(ctrlZoom)) {
+          result.cameraZoom = Number(ctrlZoom.toFixed(2))
+        } else {
+          const camZoom = control?.camera?.zoom
+          if (Number.isFinite(camZoom)) {
+            result.cameraZoom = Number(camZoom.toFixed(2))
+          }
+        }
+      } else {
+        if (Number.isFinite(control.distance)) {
+          result.cDistance = Number(control.distance.toFixed(2))
+        }
+      }
+      return result
+    }
+
+    const handleSleep = () => {
+      onUpdate({ ...getAngles(), ...getZoomDistance() })
+    }
+
+    control.addEventListener('sleep', handleSleep)
+
+    return () => {
+      control.removeEventListener('sleep', handleSleep)
+    }
+  }, [ref, props])
+
   return (
     // @ts-ignore
     <cameraControls
@@ -23,9 +71,21 @@ export function CameraControl({
       enableDamping={true}
       smoothTime={smoothTime}
       zoomSpeed={10}
-      dollySpeed={10}
-      // zoomSpeed={5}
+      dollySpeed={5}
+      maxDistance={1000}
       restThreshold={0}
+      mouseButtons={{
+        left: (CameraControls as any).ACTION.ROTATE,
+        middle:
+          props.type === 'sphere'
+            ? (CameraControls as any).ACTION.ZOOM
+            : (CameraControls as any).ACTION.DOLLY,
+        // right: (CameraControls as any).ACTION.TRUCK, // disabling pan for now, as we don't support camera position value in props
+        wheel:
+          props.type === 'sphere'
+            ? (CameraControls as any).ACTION.ZOOM
+            : (CameraControls as any).ACTION.DOLLY,
+      }}
     />
   )
 }

--- a/packages/shadergradient-v2/src/ShaderGradient/ShaderGradient.tsx
+++ b/packages/shadergradient-v2/src/ShaderGradient/ShaderGradient.tsx
@@ -8,7 +8,7 @@ import * as qs from 'query-string'
 import { formatUrlString } from '@/utils'
 
 export function ShaderGradient(passedProps: GradientT) {
-  const { control, urlString, ...rest } = {
+  const { control, urlString, onChange, ...rest } = {
     ...presets.halo.props,
     ...passedProps,
   }
@@ -24,6 +24,10 @@ export function ShaderGradient(passedProps: GradientT) {
   const { lightType, envPreset, brightness, grain, toggleAxis, ...others } =
     props
 
+  const handleUpdate = (updates: Partial<GradientT>) => {
+    onChange?.(updates)
+  }
+
   return (
     <>
       <Mesh {...props} />
@@ -34,7 +38,7 @@ export function ShaderGradient(passedProps: GradientT) {
       />
       {grain !== 'off' && <PostProcessing />}
 
-      <Controls {...props} />
+      <Controls {...props} onUpdate={handleUpdate} />
     </>
   )
 }

--- a/packages/shadergradient-v2/src/ShaderGradient/ShaderGradient.tsx
+++ b/packages/shadergradient-v2/src/ShaderGradient/ShaderGradient.tsx
@@ -8,7 +8,7 @@ import * as qs from 'query-string'
 import { formatUrlString } from '@/utils'
 
 export function ShaderGradient(passedProps: GradientT) {
-  const { control, urlString, onChange, ...rest } = {
+  const { control, urlString, onCameraUpdate, ...rest } = {
     ...presets.halo.props,
     ...passedProps,
   }
@@ -24,10 +24,6 @@ export function ShaderGradient(passedProps: GradientT) {
   const { lightType, envPreset, brightness, grain, toggleAxis, ...others } =
     props
 
-  const handleUpdate = (updates: Partial<GradientT>) => {
-    onChange?.(updates)
-  }
-
   return (
     <>
       <Mesh {...props} />
@@ -38,7 +34,7 @@ export function ShaderGradient(passedProps: GradientT) {
       />
       {grain !== 'off' && <PostProcessing />}
 
-      <Controls {...props} onUpdate={handleUpdate} />
+      <Controls {...props} onCameraUpdate={onCameraUpdate} />
     </>
   )
 }

--- a/packages/shadergradient-v2/src/types.ts
+++ b/packages/shadergradient-v2/src/types.ts
@@ -81,5 +81,5 @@ export type GradientT = MeshT & {
   urlString?: string
 
   // Event handlers
-  onChange?: (updates: Partial<GradientT>) => void
+  onCameraUpdate?: (updates: Partial<GradientT>) => void
 }

--- a/packages/shadergradient-v2/src/types.ts
+++ b/packages/shadergradient-v2/src/types.ts
@@ -79,4 +79,7 @@ export type GradientT = MeshT & {
   enableTransition?: boolean
 
   urlString?: string
+
+  // Event handlers
+  onChange?: (updates: Partial<GradientT>) => void
 }

--- a/packages/ui/src/components/Shared/ShaderGradientStateless/ShaderGradientStateless.tsx
+++ b/packages/ui/src/components/Shared/ShaderGradientStateless/ShaderGradientStateless.tsx
@@ -15,7 +15,7 @@ export function ShaderGradientStateless(passedProps: GradientT): JSX.Element {
   return (
     <ShaderGradient
       {...props}
-      onChange={(updates) => {
+      onCameraUpdate={(updates) => {
         const { cAzimuthAngle, cPolarAngle, cDistance, cameraZoom } = updates
         // defer writing to the URL store; useQueryState itself handles URL push
         if (typeof window !== 'undefined') {

--- a/packages/ui/src/components/Shared/ShaderGradientStateless/ShaderGradientStateless.tsx
+++ b/packages/ui/src/components/Shared/ShaderGradientStateless/ShaderGradientStateless.tsx
@@ -12,7 +12,28 @@ export function ShaderGradientStateless(passedProps: GradientT): JSX.Element {
   useSearchParamToStore() // init gradient state with url query
   const props = useControlValues(passedProps.control, passedProps) // make props using url query, control and passed props
 
-  return <ShaderGradient {...props} />
+  return (
+    <ShaderGradient
+      {...props}
+      onChange={(updates) => {
+        const { cAzimuthAngle, cPolarAngle, cDistance, cameraZoom } = updates
+        // defer writing to the URL store; useQueryState itself handles URL push
+        if (typeof window !== 'undefined') {
+          // Lazy import to avoid coupling at build time; same store contract
+          const { useQueryStore } = require('./store')
+          const next: any = {}
+          if (typeof cAzimuthAngle !== 'undefined')
+            next.cAzimuthAngle = cAzimuthAngle
+          if (typeof cPolarAngle !== 'undefined') next.cPolarAngle = cPolarAngle
+          if (typeof cDistance !== 'undefined') next.cDistance = cDistance
+          if (typeof cameraZoom !== 'undefined') next.cameraZoom = cameraZoom
+          if (Object.keys(next).length) {
+            useQueryStore.setState(next)
+          }
+        }
+      }}
+    />
+  )
 }
 
 ShaderGradientStateless.propertyControls = propertyControls(

--- a/packages/ui/src/overrides/FigmaPlugin/UI.tsx
+++ b/packages/ui/src/overrides/FigmaPlugin/UI.tsx
@@ -41,6 +41,7 @@ const useStore = createStore({
   currentTab: 0,
   scrollingTo: null,
   share: 'url', // url or code
+  easyView: false,
 })
 
 // 🟢 ON 'SNAPSHOT' BUTTON
@@ -742,7 +743,22 @@ export function HighlightButton(Component): ComponentType {
             ? 'ToggleBtn - Highlight'
             : 'ToggleBtn - Default'
         }
+        onClick={() => {
+          //@ts-ignore
+          props.onClick()
+          setStore({ easyView: !store.easyView })
+        }}
       />
+    )
+  }
+}
+
+// 🟢 On the ShaderGradientStateless
+export function EasyViewControl(Component): ComponentType {
+  return (props) => {
+    const [store, setStore] = useStore()
+    return (
+      <Component {...props} pointerEvents={store.easyView ? 'auto' : 'none'} />
     )
   }
 }


### PR DESCRIPTION
- update base camera control to update camera angle/distance/zoom when the camera update ends (sleep event)
- update Shadergradientstateless to update the query on change
- adding new override on Figma plugin to allow pointerEvents on shadergradient when the easy view control is on