### PR TITLE
fix: remove ShaderGradient-owned THREE.Clock usage

### DIFF
--- a/.changeset/fix-deprecated-three-clock.md
+++ b/.changeset/fix-deprecated-three-clock.md
@@ -1,0 +1,5 @@
+---
+'@shadergradient/react': patch
+---
+
+Remove ShaderGradient's direct usage of the deprecated `THREE.Clock` API and use the render loop delta for animation timing. React Three Fiber versions that still construct `THREE.Clock` may continue to emit their own warning.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.12.4
+          run_install: false
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Test timing behavior
+        run: pnpm --filter=@shadergradient/react test
+
+      - name: Build package
+        run: pnpm --filter=@shadergradient/react build
+
+      - name: Build Framer package
+        run: pnpm --filter=@shadergradient/react build:framer

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 
 # testing
 coverage
+.test-dist
 
 # next.js
 .next/

--- a/packages/shadergradient/package.json
+++ b/packages/shadergradient/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "build": "tsup",
+    "test": "tsup --config tsup.test.config.ts && node .test-dist/animationTime.test.js",
     "dev": "tsup --config tsup.config.ts --watch",
     "dev:ui": "tsup --config tsup.config.ts",
     "dev:framer": "concurrently \"tsup --config tsup.framer.config.ts --watch\" \"pnpm ngrok\"",

--- a/packages/shadergradient/src/ShaderGradient/Mesh/Materials.tsx
+++ b/packages/shadergradient/src/ShaderGradient/Mesh/Materials.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef } from 'react'
 import * as THREE from 'three'
 import { colorToRgb, formatColor } from '@/utils'
 import { useFrame } from '@react-three/fiber'
+import { advanceAnimationTime } from './animationTime'
 
 // Define the material component
 export const Materials = ({
@@ -18,7 +19,7 @@ export const Materials = ({
   onInit,
   shader,
 }) => {
-  const localClockRef = useRef(new THREE.Clock())
+  const elapsedTimeRef = useRef(0)
   const material = useMemo(() => {
     const entries = Object.entries(uniforms)
     const colors = uniforms.colors
@@ -97,56 +98,41 @@ export const Materials = ({
     }
   }, [material])
 
-  // Sync clock with animate/range changes similar to v1's useTimeAnimation
+  // Restart the animation whenever it is enabled.
   useEffect(() => {
     if (animate === 'on') {
-      localClockRef.current.start()
-    } else {
-      localClockRef.current.stop()
+      elapsedTimeRef.current = 0
     }
   }, [animate])
 
   // Animate uTime with useFrame (v1-like behavior)
-  useFrame(() => {
-    if (animate === 'on' && material.userData.uTime) {
-      let elapsed = localClockRef.current.getElapsedTime()
+  useFrame((_, delta) => {
+    if (animate !== 'on') return
 
-      // Handle loop functionality
-      if (loop === 'on' && Number.isFinite(loopDuration) && loopDuration > 0) {
-        // For seamless loops, we need to ensure the time wraps around smoothly
-        // The shader will handle the circular sampling to make it truly seamless
-        elapsed = elapsed % loopDuration
-
-        // Update loop uniforms
-        if (material.userData.uLoop) {
-          material.userData.uLoop.value = 1.0
-        }
-        if (material.userData.uLoopDuration) {
-          material.userData.uLoopDuration.value = loopDuration
-        }
-      } else {
-        // Disable loop in shader
-        if (material.userData.uLoop) {
-          material.userData.uLoop.value = 0.0
-        }
-
-        if (
-          range === 'enabled' &&
-          Number.isFinite(rangeStart) &&
-          Number.isFinite(rangeEnd) &&
-          rangeEnd > rangeStart
-        ) {
-          elapsed = (rangeStart as number) + elapsed
-          if (elapsed >= (rangeEnd as number)) {
-            elapsed = rangeStart as number
-            // restart the local clock to loop precisely from rangeStart
-            localClockRef.current.start()
-          }
-        }
-      }
-
-      material.userData.uTime.value = elapsed
+    // Keep time advancing while the uniform is temporarily unavailable.
+    if (!material.userData.uTime) {
+      elapsedTimeRef.current += delta
+      return
     }
+
+    const frame = advanceAnimationTime(elapsedTimeRef.current, delta, {
+      range,
+      rangeStart,
+      rangeEnd,
+      loop,
+      loopDuration,
+    })
+
+    elapsedTimeRef.current = frame.elapsedTime
+
+    if (material.userData.uLoop) {
+      material.userData.uLoop.value = frame.uLoop
+    }
+    if (frame.uLoopDuration !== undefined && material.userData.uLoopDuration) {
+      material.userData.uLoopDuration.value = frame.uLoopDuration
+    }
+
+    material.userData.uTime.value = frame.uTime
   })
 
   return <primitive attach='material' object={material} />

--- a/packages/shadergradient/src/ShaderGradient/Mesh/animationTime.ts
+++ b/packages/shadergradient/src/ShaderGradient/Mesh/animationTime.ts
@@ -1,0 +1,68 @@
+type AnimationTimeConfig = {
+  range?: string
+  rangeStart?: number
+  rangeEnd?: number
+  loop?: 'on' | 'off'
+  loopDuration?: number
+}
+
+type AnimationTimeFrame = {
+  elapsedTime: number
+  uTime: number
+  uLoop: 0 | 1
+  uLoopDuration?: number
+}
+
+export function advanceAnimationTime(
+  elapsedTime: number,
+  delta: number,
+  { range, rangeStart, rangeEnd, loop, loopDuration }: AnimationTimeConfig
+): AnimationTimeFrame {
+  const nextElapsedTime = elapsedTime + delta
+  const hasValidLoop =
+    loop === 'on' &&
+    typeof loopDuration === 'number' &&
+    Number.isFinite(loopDuration) &&
+    loopDuration > 0
+
+  if (hasValidLoop) {
+    return {
+      elapsedTime: nextElapsedTime,
+      uTime: nextElapsedTime % loopDuration,
+      uLoop: 1,
+      uLoopDuration: loopDuration,
+    }
+  }
+
+  const hasValidRange =
+    range === 'enabled' &&
+    typeof rangeStart === 'number' &&
+    Number.isFinite(rangeStart) &&
+    typeof rangeEnd === 'number' &&
+    Number.isFinite(rangeEnd) &&
+    rangeEnd > rangeStart
+
+  if (hasValidRange) {
+    const rangedTime = rangeStart + nextElapsedTime
+
+    if (rangedTime >= rangeEnd) {
+      return {
+        elapsedTime: 0,
+        uTime: rangeStart,
+        uLoop: 0,
+      }
+    }
+
+    return {
+      elapsedTime: nextElapsedTime,
+      uTime: rangedTime,
+      uLoop: 0,
+    }
+  }
+
+  return {
+    elapsedTime: nextElapsedTime,
+    uTime: nextElapsedTime,
+    uLoop: 0,
+  }
+}

--- a/packages/shadergradient/src/ShaderGradient/PostProcessing/lib/pp/from-threejs/postprocessing/EffectComposer.js
+++ b/packages/shadergradient/src/ShaderGradient/PostProcessing/lib/pp/from-threejs/postprocessing/EffectComposer.js
@@ -1,6 +1,5 @@
 import {
   BufferGeometry,
-  Clock,
   Float32BufferAttribute,
   LinearFilter,
   Mesh,
@@ -65,7 +64,7 @@ class EffectComposer {
 
     this.copyPass = new ShaderPass(CopyShader)
 
-    this.clock = new Clock()
+    this.previousFrameTime = undefined
   }
 
   swapBuffers() {
@@ -109,10 +108,15 @@ class EffectComposer {
   }
 
   render(deltaTime) {
-    // deltaTime value is in seconds
-
+    // React Three Fiber supplies deltaTime in seconds. Keep the original
+    // no-argument behavior for any callers that render the composer directly.
     if (deltaTime === undefined) {
-      deltaTime = this.clock.getDelta()
+      const currentTime = performance.now()
+      deltaTime =
+        this.previousFrameTime === undefined
+          ? 0
+          : (currentTime - this.previousFrameTime) / 1000
+      this.previousFrameTime = currentTime
     }
 
     const currentRenderTarget = this.renderer.getRenderTarget()

--- a/packages/shadergradient/test/animationTime.test.ts
+++ b/packages/shadergradient/test/animationTime.test.ts
@@ -1,0 +1,200 @@
+import assert from 'assert/strict'
+import { readFileSync, readdirSync } from 'fs'
+import { join, resolve } from 'path'
+import { advanceAnimationTime } from '../src/ShaderGradient/Mesh/animationTime'
+import { EffectComposer } from '../src/ShaderGradient/PostProcessing/lib/pp/from-threejs/postprocessing/EffectComposer.js'
+
+const test = (name: string, run: () => void) => {
+  try {
+    run()
+    console.log(`✔ ${name}`)
+  } catch (error) {
+    console.error(`✘ ${name}`)
+    throw error
+  }
+}
+
+const assertClose = (actual: number, expected: number) => {
+  assert.ok(
+    Math.abs(actual - expected) < 1e-9,
+    `Expected ${actual} to be close to ${expected}`
+  )
+}
+
+const listSourceFiles = (directory: string): string[] =>
+  readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name)
+
+    if (entry.isDirectory()) return listSourceFiles(path)
+    return /\.(?:js|ts|tsx)$/.test(entry.name) ? [path] : []
+  })
+
+test('accumulates only the supplied frame delta', () => {
+  const first = advanceAnimationTime(0, 0.25, {})
+  const second = advanceAnimationTime(first.elapsedTime, 0.5, {})
+
+  assert.deepEqual(first, { elapsedTime: 0.25, uTime: 0.25, uLoop: 0 })
+  assert.deepEqual(second, { elapsedTime: 0.75, uTime: 0.75, uLoop: 0 })
+})
+
+test('supports pause and restart semantics without seeding from the uniform', () => {
+  let elapsedTime = 0
+  let uTime = 8
+
+  const running = advanceAnimationTime(elapsedTime, 0.5, {})
+  elapsedTime = running.elapsedTime
+  uTime = running.uTime
+
+  // animate='off' does not call the helper, so both values remain frozen.
+  assert.equal(elapsedTime, 0.5)
+  assert.equal(uTime, 0.5)
+
+  // animate='on' resets the elapsed ref before the next frame.
+  elapsedTime = 0
+  const restarted = advanceAnimationTime(elapsedTime, 0.25, {})
+  assert.deepEqual(restarted, { elapsedTime: 0.25, uTime: 0.25, uLoop: 0 })
+})
+
+test('offsets valid ranges and discards overshoot at the end boundary', () => {
+  const config = { range: 'enabled', rangeStart: 2, rangeEnd: 5 }
+  const beforeEnd = advanceAnimationTime(2.8, 0.1, config)
+  const atEnd = advanceAnimationTime(beforeEnd.elapsedTime, 0.1, config)
+  const afterReset = advanceAnimationTime(atEnd.elapsedTime, 0.25, config)
+
+  assertClose(beforeEnd.uTime, 4.9)
+  assertClose(beforeEnd.elapsedTime, 2.9)
+  assert.deepEqual(atEnd, { elapsedTime: 0, uTime: 2, uLoop: 0 })
+  assert.deepEqual(afterReset, { elapsedTime: 0.25, uTime: 2.25, uLoop: 0 })
+
+  const overshoot = advanceAnimationTime(2.9, 0.5, config)
+  assert.deepEqual(overshoot, { elapsedTime: 0, uTime: 2, uLoop: 0 })
+})
+
+test('falls back to unbounded time for invalid ranges', () => {
+  const invalidRanges = [
+    { range: 'enabled', rangeStart: 2, rangeEnd: 2 },
+    { range: 'enabled', rangeStart: 3, rangeEnd: 2 },
+    { range: 'enabled', rangeStart: Number.NaN, rangeEnd: 5 },
+    { range: 'enabled', rangeStart: 2, rangeEnd: Number.POSITIVE_INFINITY },
+    { range: 'disabled', rangeStart: 2, rangeEnd: 5 },
+  ]
+
+  for (const config of invalidRanges) {
+    assert.deepEqual(advanceAnimationTime(1, 0.5, config), {
+      elapsedTime: 1.5,
+      uTime: 1.5,
+      uLoop: 0,
+    })
+  }
+})
+
+test('wraps valid loops while retaining the raw elapsed time', () => {
+  const frame = advanceAnimationTime(4.9, 0.2, {
+    loop: 'on',
+    loopDuration: 5,
+  })
+
+  assertClose(frame.elapsedTime, 5.1)
+  assertClose(frame.uTime, 0.1)
+  assert.equal(frame.uLoop, 1)
+  assert.equal(frame.uLoopDuration, 5)
+
+  const changedDuration = advanceAnimationTime(frame.elapsedTime, 0, {
+    loop: 'on',
+    loopDuration: 2,
+  })
+  assertClose(changedDuration.uTime, 1.1)
+
+  const loopDisabled = advanceAnimationTime(frame.elapsedTime, 0, {
+    loop: 'off',
+    loopDuration: 5,
+  })
+  assertClose(loopDisabled.uTime, 5.1)
+  assert.equal(loopDisabled.uLoopDuration, undefined)
+})
+
+test('gives valid loops precedence over ranges', () => {
+  const frame = advanceAnimationTime(4.9, 0.2, {
+    loop: 'on',
+    loopDuration: 5,
+    range: 'enabled',
+    rangeStart: 10,
+    rangeEnd: 12,
+  })
+
+  assertClose(frame.elapsedTime, 5.1)
+  assertClose(frame.uTime, 0.1)
+  assert.equal(frame.uLoop, 1)
+})
+
+test('invalid loop durations disable looping and fall through to ranges', () => {
+  const invalidDurations = [0, -1, Number.NaN, Number.POSITIVE_INFINITY]
+
+  for (const loopDuration of invalidDurations) {
+    const frame = advanceAnimationTime(0.5, 0.25, {
+      loop: 'on',
+      loopDuration,
+      range: 'enabled',
+      rangeStart: 2,
+      rangeEnd: 5,
+    })
+
+    assert.deepEqual(frame, { elapsedTime: 0.75, uTime: 2.75, uLoop: 0 })
+  }
+})
+
+test('keeps elapsed state independent between animation instances', () => {
+  const first = advanceAnimationTime(0, 0.25, {})
+  const second = advanceAnimationTime(0, 1, {})
+  const firstAgain = advanceAnimationTime(first.elapsedTime, 0.25, {})
+
+  assert.equal(firstAgain.elapsedTime, 0.5)
+  assert.equal(second.elapsedTime, 1)
+})
+
+test('does not use the deprecated Clock API in ShaderGradient-owned source', () => {
+  const sourceRoot = resolve(process.cwd(), 'src/ShaderGradient')
+  const clockReferences = listSourceFiles(sourceRoot)
+    .filter((path) => /\bClock\b/.test(readFileSync(path, 'utf8')))
+    .map((path) => path.slice(sourceRoot.length + 1))
+
+  assert.deepEqual(clockReferences, [])
+})
+
+test('passes explicit and fallback frame deltas through EffectComposer', () => {
+  const makeRenderTarget = () => ({
+    width: 1,
+    height: 1,
+    texture: { name: '' },
+    clone: makeRenderTarget,
+    dispose: () => undefined,
+    setSize: () => undefined,
+  })
+  let currentRenderTarget = null
+  const renderer = {
+    getRenderTarget: () => currentRenderTarget,
+    setRenderTarget: (target) => {
+      currentRenderTarget = target
+    },
+  }
+  const composer = new EffectComposer(renderer, makeRenderTarget())
+  const deltas: number[] = []
+
+  composer.addPass({
+    enabled: true,
+    needsSwap: false,
+    setSize: () => undefined,
+    render: (_renderer, _writeBuffer, _readBuffer, deltaTime) => {
+      deltas.push(deltaTime)
+    },
+  })
+
+  composer.render(0.25)
+  composer.render()
+  composer.previousFrameTime = performance.now() - 100
+  composer.render()
+
+  assert.equal(deltas[0], 0.25)
+  assert.equal(deltas[1], 0)
+  assert.ok(deltas[2] >= 0.09)
+})

--- a/packages/shadergradient/tsup.test.config.ts
+++ b/packages/shadergradient/tsup.test.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['test/animationTime.test.ts'],
+  clean: true,
+  dts: false,
+  format: ['cjs'],
+  outDir: '.test-dist',
+  platform: 'node',
+  target: 'node14',
+})


### PR DESCRIPTION
## Summary

- replace ShaderGradient material timing with React Three Fiber frame deltas while preserving restart, range, and loop behavior
- remove the deprecated Clock dependency from the vendored EffectComposer while preserving its no-argument delta fallback
- add timing, composer, and deprecated API regression tests, plus a PR test workflow and patch changeset

## Validation

- `pnpm --filter=@shadergradient/react test` — 10 tests passed
- `pnpm --filter=@shadergradient/react build`
- `pnpm --filter=@shadergradient/react build:framer`
- Prettier and `git diff --check`
- browser fixture with Three 0.183.2 and 0.185.1: bare Canvas / grain off / grain on warnings changed from `1 / 2 / 3` to `1 / 1 / 1`

## Compatibility note

ShaderGradient no longer adds any Clock warnings. Stable React Three Fiber 8 and 9 releases still construct `THREE.Clock` internally, so one upstream warning remains with recent Three releases. Moving to R3F 10 should be handled separately after it stabilizes because it raises the React and Three requirements.

Addresses #158